### PR TITLE
PR - Phase 2 Step 1 - Platform Hardening Baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,19 @@ jobs:
       - name: Sync dependencies
         run: uv sync --frozen --all-groups
 
-      - name: Run backend tests
-        run: uv run pytest tests/
+      - name: Verify backend lockfile exists
+        run: test -f uv.lock
+
+      - name: Run backend tests with coverage gate
+        run: |
+          uv run pytest tests/ \
+            --cov=alphawatch \
+            --cov-report=term-missing \
+            --cov-report=json:coverage.json \
+            --cov-fail-under=74
+
+      - name: Enforce critical-path coverage thresholds
+        run: uv run python scripts/ci/coverage_gate.py coverage.json
 
       - name: Run mypy
         run: uv run mypy alphawatch/ || echo '::warning::mypy found type errors (non-blocking for Phase 1)'
@@ -51,6 +62,9 @@ jobs:
 
       - name: Install frontend deps
         run: npm ci
+
+      - name: Verify frontend lockfile exists
+        run: test -f package-lock.json
 
       - name: Frontend tests
         run: npm test -- --passWithNoTests

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,7 @@
 name: Deploy Staging
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -2,6 +2,12 @@ name: Release Production
 
 on:
   workflow_dispatch:
+    inputs:
+      plan_only:
+        description: "Run terraform plan only (skip apply and rollout checks)"
+        required: false
+        default: false
+        type: boolean
   push:
     tags:
       - "v*"
@@ -28,10 +34,12 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
 
       - name: Login to Amazon ECR
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build and push API image
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_API_REPOSITORY }}
@@ -41,6 +49,7 @@ jobs:
           docker push "$REGISTRY/$REPOSITORY:$IMAGE_TAG"
 
       - name: Build and push worker image
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_WORKER_REPOSITORY }}
@@ -56,12 +65,40 @@ jobs:
           API_REPOSITORY: ${{ vars.ECR_API_REPOSITORY }}
           WORKER_REPOSITORY: ${{ vars.ECR_WORKER_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
+          CLUSTER_NAME: alphawatch-production
+          API_SERVICE_NAME: alphawatch-production-api
+          WORKER_SERVICE_NAME: alphawatch-production-worker
         run: |
-          echo "api_image_uri=$REGISTRY/$API_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-          echo "worker_image_uri=$REGISTRY/$WORKER_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.plan_only }}" == "true" ]]; then
+            API_TASK_DEF=$(aws ecs describe-services \
+              --cluster "$CLUSTER_NAME" \
+              --services "$API_SERVICE_NAME" \
+              --query 'services[0].taskDefinition' \
+              --output text)
+            WORKER_TASK_DEF=$(aws ecs describe-services \
+              --cluster "$CLUSTER_NAME" \
+              --services "$WORKER_SERVICE_NAME" \
+              --query 'services[0].taskDefinition' \
+              --output text)
+
+            API_IMAGE_URI=$(aws ecs describe-task-definition \
+              --task-definition "$API_TASK_DEF" \
+              --query 'taskDefinition.containerDefinitions[?name==`api`].image | [0]' \
+              --output text)
+            WORKER_IMAGE_URI=$(aws ecs describe-task-definition \
+              --task-definition "$WORKER_TASK_DEF" \
+              --query 'taskDefinition.containerDefinitions[?name==`worker`].image | [0]' \
+              --output text)
+
+            echo "api_image_uri=$API_IMAGE_URI" >> "$GITHUB_OUTPUT"
+            echo "worker_image_uri=$WORKER_IMAGE_URI" >> "$GITHUB_OUTPUT"
+          else
+            echo "api_image_uri=$REGISTRY/$API_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+            echo "worker_image_uri=$REGISTRY/$WORKER_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          fi
 
   deploy:
-    name: Terraform apply + ECS rollout + smoke test
+    name: Terraform deploy or plan-only validation
     runs-on: ubuntu-latest
     needs: build
     environment: production
@@ -94,11 +131,17 @@ jobs:
             -var "worker_image=${{ needs.build.outputs.worker_image_uri }}" \
             -out=tfplan
 
+      - name: Plan-only summary
+        if: github.event_name == 'workflow_dispatch' && inputs.plan_only
+        run: echo "Plan-only mode enabled; skipping apply, rollout waits, and smoke checks."
+
       - name: Terraform apply
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         working-directory: infra/environments/production
         run: terraform apply -input=false -auto-approve tfplan
 
       - name: Capture Terraform outputs
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         id: tf
         working-directory: infra/environments/production
         run: |
@@ -110,19 +153,21 @@ jobs:
           echo "cloudfront_distribution_id=$(terraform output -raw cloudfront_distribution_id)" >> "$GITHUB_OUTPUT"
 
       - name: Wait for ECS API service stability
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         run: |
           aws ecs wait services-stable \
             --cluster "${{ steps.tf.outputs.cluster_name }}" \
             --services "${{ steps.tf.outputs.api_service_name }}"
 
       - name: Wait for ECS worker service stability
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         run: |
           aws ecs wait services-stable \
             --cluster "${{ steps.tf.outputs.cluster_name }}" \
             --services "${{ steps.tf.outputs.worker_service_name }}"
 
       - name: Deploy frontend static assets (optional)
-        if: vars.DEPLOY_FRONTEND_STATIC == 'true'
+        if: (github.event_name != 'workflow_dispatch' || !inputs.plan_only) && vars.DEPLOY_FRONTEND_STATIC == 'true'
         run: |
           npm ci
           npm run build
@@ -130,17 +175,19 @@ jobs:
           aws s3 sync out/ "s3://${{ steps.tf.outputs.frontend_bucket_id }}/" --delete
 
       - name: Invalidate CloudFront cache (optional)
-        if: vars.DEPLOY_FRONTEND_STATIC == 'true'
+        if: (github.event_name != 'workflow_dispatch' || !inputs.plan_only) && vars.DEPLOY_FRONTEND_STATIC == 'true'
         run: |
           aws cloudfront create-invalidation \
             --distribution-id "${{ steps.tf.outputs.cloudfront_distribution_id }}" \
             --paths "/*"
 
       - name: Smoke test health endpoint
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         run: |
           curl --fail --show-error --silent "http://${{ steps.tf.outputs.alb_dns_name }}/health"
 
       - name: Smoke test authenticated path enforcement
+        if: github.event_name != 'workflow_dispatch' || !inputs.plan_only
         run: |
           STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" \
             "http://${{ steps.tf.outputs.alb_dns_name }}/api/watchlist")

--- a/README.md
+++ b/README.md
@@ -389,8 +389,12 @@ npx tsc --noEmit
 - [`docs/project-status.md`](docs/project-status.md) — Detailed phase and step tracking
 - [`AGENTS.md`](AGENTS.md) — AI agent guidance, graph shapes, and architecture reference
 - [`developer/developer-journal.md`](developer/developer-journal.md) — Development log
-- [`github/ISSUES/phase-2-intelligence.md`](github/ISSUES/phase-2-intelligence.md) — Phase 2 epic + issue breakdown
-- [`github/PROJECTS/phase-2-intelligence.md`](github/PROJECTS/phase-2-intelligence.md) — Phase 2 project board template
+- [`docs/phase2-step1-hardening.md`](docs/phase2-step1-hardening.md) — Step 1 execution checklist (IAM, CI gates, deploy guardrails, migration drill)
+- [`docs/phase2-step2-runtime-foundations-spec.md`](docs/phase2-step2-runtime-foundations-spec.md) — Step 2 architecture and execution spec
+- [`docs/phase2-step3-news-ingestion-spec.md`](docs/phase2-step3-news-ingestion-spec.md) — Step 3 multi-source ingestion spec
+- [`docs/phase2-operations-runbook-news-sources.md`](docs/phase2-operations-runbook-news-sources.md) — News source operations runbook
+- [Phase 2 Epic (GitHub issue)](https://github.com/Bytes0211/aIphawatch/issues/26) — Phase 2 epic and issue breakdown
+- [Phase 2 Project (GitHub)](https://github.com/users/Bytes0211/projects/2) — Phase 2 project board
 
 ---
 

--- a/docs/phase2-operations-runbook-news-sources.md
+++ b/docs/phase2-operations-runbook-news-sources.md
@@ -1,0 +1,105 @@
+# Phase 2 Operations Runbook — News Source Ingestion
+
+## Purpose
+
+Operational procedures for running and troubleshooting multi-source news ingestion after Step 3 rollout.
+
+---
+
+## Daily Checks
+
+1. Provider success rate by source.
+2. Quota utilization per source.
+3. Dedup ratio and merged article volume.
+4. End-to-end sentiment pipeline completion rate.
+
+---
+
+## Key Metrics
+
+1. `news_ingest_requests_total{provider,status}`
+2. `news_ingest_quota_remaining{provider}`
+3. `news_dedup_drop_total{provider}`
+4. `news_articles_merged_total`
+5. `sentiment_pipeline_failures_total`
+
+---
+
+## Alert Recommendations
+
+1. Provider error rate > 10% over 15m.
+2. Quota remaining < 10% before end of daily window.
+3. Dedup drop ratio > 80% for 30m (possible canonicalization bug).
+4. Sentiment pipeline failure rate > 5% for 15m.
+
+---
+
+## Common Failure Modes
+
+### 1) Provider auth/rate failure
+
+Symptoms:
+
+1. Sudden increase in provider-specific 401/429/5xx.
+2. Drop in merged article count.
+
+Actions:
+
+1. Validate API key/secret rotation state.
+2. Confirm quota settings and current usage.
+3. Temporarily lower provider priority and continue with remaining sources.
+
+### 2) Over-aggressive dedup
+
+Symptoms:
+
+1. Merged article count collapses while provider pulls remain healthy.
+2. Dedup ratio spikes unexpectedly.
+
+Actions:
+
+1. Inspect canonicalization output sample.
+2. Switch to conservative fallback key.
+3. Roll back recent dedup rule changes.
+
+### 3) Pipeline partial failure propagation
+
+Symptoms:
+
+1. News ingest returns but sentiment records are missing.
+
+Actions:
+
+1. Verify `fetch_news` output shape in sentiment node logs.
+2. Validate required metadata fields.
+3. Re-run ingestion for impacted tickers after fix.
+
+---
+
+## Incident Response
+
+1. Declare incident severity.
+2. Capture failing provider, timeframe, and impacted tickers.
+3. Apply fallback mode to maintain partial service.
+4. Open incident entry in `developer/developer-journal.md`.
+5. Post-incident: add regression test for root cause.
+
+---
+
+## Change Management
+
+Before changing provider adapters, dedup logic, or quotas:
+
+1. Run staging ingestion dry-run for representative tickers.
+2. Compare dedup ratio against baseline.
+3. Confirm alert thresholds still valid.
+4. Update this runbook and Step 3 spec if behavior changes.
+
+---
+
+## Exit Criteria for Stable Operations
+
+1. 7 consecutive days with no sev-1/sev-2 ingestion incidents.
+2. Provider fallback behavior validated in at least one staged fault injection.
+3. Alert noise rate acceptable (no sustained false positives).
+4. On-call troubleshooting steps validated and current.

--- a/docs/phase2-step1-hardening.md
+++ b/docs/phase2-step1-hardening.md
@@ -1,0 +1,163 @@
+# Phase 2 Step 1 — Platform Hardening Baseline Runbook
+
+Execution checklist for the pre-Phase 2 hardening baseline.
+
+---
+
+## Scope
+
+This runbook covers Step 1 deliverables:
+
+1. Remove temporary broad production IAM access and validate least privilege.
+2. Verify reproducible dependency locks for backend and frontend.
+3. Enable CI quality gates (total + critical-path coverage).
+4. Establish baseline observability metrics and alert thresholds.
+5. Run one migration safety drill (backup, restore, rollback rehearsal).
+6. Freeze docs/runbooks for Phase 2 start.
+
+---
+
+## 1. IAM Least-Privilege Validation
+
+Use `developer/runbooks/policy_validation.md` for policy content and trust checks.
+
+Required end-state:
+
+- `PowerUserAccess` is detached from `alphawatch-github-production`.
+- Staging deploy workflow succeeds.
+- Production plan-only workflow succeeds.
+
+Verify attached managed policies:
+
+```bash
+aws iam list-attached-role-policies \
+  --role-name alphawatch-github-production \
+  --query 'AttachedPolicies[].{Name:PolicyName,Arn:PolicyArn}' \
+  --output table
+```
+
+If temporary broad access still exists:
+
+```bash
+aws iam detach-role-policy \
+  --role-name alphawatch-github-production \
+  --policy-arn arn:aws:iam::aws:policy/PowerUserAccess
+```
+
+---
+
+## 2. Reproducible Build Locks
+
+Backend lock check:
+
+```bash
+test -f uv.lock
+uv sync --frozen --all-groups
+```
+
+Frontend lock check:
+
+```bash
+test -f package-lock.json
+npm ci
+```
+
+CI enforces lockfile presence and frozen dependency resolution.
+
+---
+
+## 3. CI Quality Gates
+
+CI now enforces:
+
+- Total backend coverage floor via `--cov-fail-under=74`
+- Critical-path coverage thresholds via `scripts/ci/coverage_gate.py`
+
+Critical-path thresholds:
+
+- `alphawatch/agents/nodes/chat.py`: >= 90%
+- `alphawatch/agents/nodes/brief.py`: >= 90%
+- `alphawatch/services/financial.py`: >= 70%
+
+Local validation command:
+
+```bash
+uv run pytest tests/ \
+  --cov=alphawatch \
+  --cov-report=term-missing \
+  --cov-report=json:coverage.json \
+  --cov-fail-under=74
+uv run python scripts/ci/coverage_gate.py coverage.json
+```
+
+---
+
+## 4. Deploy Guardrails Validation
+
+### Staging (full deploy)
+
+Run `Deploy Staging` from latest `main` and verify:
+
+- Terraform apply succeeds
+- ECS API + worker wait steps succeed
+- Smoke tests pass (`/health`, auth 401 on `/api/watchlist`)
+
+### Production (plan-only)
+
+Run `Release Production` with `workflow_dispatch` input:
+
+- `plan_only=true`
+
+Expected behavior:
+
+- Terraform plan runs successfully
+- Apply, rollout wait, and smoke-test steps are skipped
+
+---
+
+## 5. Baseline Observability Targets
+
+Track and alert on these metrics before Phase 2 feature rollout:
+
+1. Brief generation latency (P95)
+2. Chat response latency (P95)
+3. API error rate (5xx)
+4. Chunk cache hit rate
+5. Financial provider failure rate
+
+Initial alert guidelines:
+
+- P95 chat response > 15s for 15m
+- API 5xx rate > 2% for 10m
+- Chunk cache hit rate < 50% for 60m
+- Provider failure rate > 5% for 15m
+
+---
+
+## 6. Migration Safety Drill
+
+Run once before introducing new Phase 2 schema changes.
+
+Checklist:
+
+1. Snapshot/backup current database.
+2. Apply latest migration in staging.
+3. Execute representative smoke queries.
+4. Rehearse rollback to prior schema state.
+5. Re-run smoke queries after rollback.
+6. Record timings and failure points.
+
+Store evidence in `developer/developer-journal.md` with date, commands used, and outcomes.
+
+---
+
+## Completion Criteria
+
+Step 1 is complete when all are true:
+
+- IAM least-privilege validated with staging full deploy + production plan-only run.
+- CI quality gates are active and green.
+- Reproducible lock checks pass in CI.
+- Observability baseline and alert targets are documented and configured.
+- Migration safety drill completed and logged.
+- Phase 2 docs/runbooks updated and frozen.

--- a/docs/phase2-step2-runtime-foundations-spec.md
+++ b/docs/phase2-step2-runtime-foundations-spec.md
@@ -1,0 +1,131 @@
+# Phase 2 Step 2 — Runtime Foundations Rollout (Spec)
+
+## Purpose
+
+Define and implement runtime foundation changes needed before deeper Phase 2 feature delivery:
+
+1. Complete financial provider abstraction rollout in runtime paths.
+2. Move chat summarization off the synchronous request hot path.
+3. Add validation and regression checks for correctness and latency.
+
+---
+
+## Scope
+
+### In scope
+
+1. Replace direct provider construction in ingestion/runtime call sites with `get_financial_data_provider()`.
+2. Enforce config-driven provider selection via `Settings.financial_data_provider`.
+3. Refactor chat summarization so `maybe_summarize` work does not block chat response path.
+4. Add integration tests and runtime metrics around provider selection and summarization behavior.
+
+### Out of scope
+
+1. Adding a second financial provider implementation (this step is wiring plus contract hardening).
+2. Step 3 multi-source news ingestion work.
+
+---
+
+## Current State
+
+1. Provider abstraction exists in [alphawatch/services/financial.py](alphawatch/services/financial.py).
+2. Config key exists in [alphawatch/config.py](alphawatch/config.py).
+3. Chat summarization currently runs inline in `maybe_summarize` after `persist_turn` in [alphawatch/agents/nodes/chat.py](alphawatch/agents/nodes/chat.py).
+
+---
+
+## Target Architecture
+
+### A. Provider wiring
+
+1. Runtime entrypoints that need financial snapshots must resolve provider via factory.
+2. No direct `AlphaVantageClient()` construction in runtime/graph node code paths.
+3. Provider output normalization remains through the existing snapshot contract.
+
+### B. Summarization off hot path
+
+1. Request path returns streamed response without waiting for summarization.
+2. Summarization work runs async via background task/worker pathway.
+3. Failures in summarization do not fail user chat turn.
+4. Summary freshness is eventually consistent and persisted to `ChatSession`.
+
+---
+
+## Implementation Plan
+
+### Workstream 1: Provider factory rollout
+
+1. Search and replace remaining concrete client usage.
+2. Route call sites through `get_financial_data_provider()`.
+3. Ensure provider resolution errors are explicit and observable.
+4. Add one integration test for config-driven selection behavior.
+
+### Workstream 2: Summarization decoupling
+
+1. Introduce summary-needed signal after `persist_turn`.
+2. Dispatch summarization to async execution path (worker/task/background queue).
+3. Keep request path non-blocking and idempotent.
+4. Persist summary updates with safe conflict handling.
+
+### Workstream 3: Validation and metrics
+
+1. Add metrics for summarization queue latency, success/failure rate, and staleness.
+2. Add latency benchmark checks around threshold turns.
+3. Validate no regressions in streaming behavior.
+
+---
+
+## Acceptance Criteria
+
+1. No direct `AlphaVantageClient()` instantiation in runtime ingestion paths.
+2. Provider selection is controlled by config and covered by integration tests.
+3. Chat trigger-turn latency is not increased by summarization execution.
+4. Summarization failures are isolated from user response success path.
+5. Runtime metrics for provider failures and summarization health are emitted.
+
+---
+
+## Test Plan
+
+1. Unit: provider factory and error paths.
+2. Integration: config-based provider selection from runtime entrypoint.
+3. Integration: chat turn continues when summarization task fails.
+4. Regression: compare p95 chat latency before/after at summary threshold boundary.
+
+Suggested commands:
+
+```bash
+uv run pytest tests/test_financial.py -v
+uv run pytest tests/test_chat.py -v
+uv run pytest tests/ --cov=alphawatch --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=74
+uv run python scripts/ci/coverage_gate.py coverage.json
+```
+
+---
+
+## Rollout Plan
+
+1. Deploy to staging with feature toggle or guarded path.
+2. Validate latency and error metrics for 24h.
+3. Promote to production with plan/apply workflow gates.
+4. Monitor summarization queue depth and failure alerts.
+
+---
+
+## Risks and Mitigations
+
+1. Risk: Summary stale window increases.
+   Mitigation: bounded delay SLO and fallback to recent raw messages.
+2. Risk: Task duplication.
+   Mitigation: idempotency key per session/turn window.
+3. Risk: Provider misconfiguration.
+   Mitigation: startup/config validation plus clear error telemetry.
+
+---
+
+## Deliverables
+
+1. Updated runtime code paths using provider factory.
+2. Non-blocking summarization architecture implementation.
+3. Tests proving config selection and non-blocking behavior.
+4. Runtime metrics and alert thresholds documented.

--- a/docs/phase2-step3-news-ingestion-spec.md
+++ b/docs/phase2-step3-news-ingestion-spec.md
@@ -1,0 +1,129 @@
+# Phase 2 Step 3 — Full News Ingestion Depth (Spec)
+
+## Purpose
+
+Expand news ingestion from single-source lightweight collection to resilient multi-source ingestion with deduplication and quota-aware controls.
+
+---
+
+## Scope
+
+### In scope
+
+1. Multi-source news adapter architecture.
+2. Source-aware normalization and cross-source deduplication.
+3. Per-source quota/rate controls and graceful fallback.
+4. Metadata enrichment to support downstream sentiment weighting.
+
+### Out of scope
+
+1. Full sentiment model redesign (Step 4).
+2. Hybrid retrieval blending with uploaded docs (Step 7).
+
+---
+
+## Current State
+
+1. Single NewsAPI client in [alphawatch/services/news.py](alphawatch/services/news.py).
+2. Sentiment flow entry in `fetch_news` node at [alphawatch/agents/nodes/sentiment.py](alphawatch/agents/nodes/sentiment.py).
+3. Sentiment graph routing in [alphawatch/agents/graphs/sentiment.py](alphawatch/agents/graphs/sentiment.py).
+
+---
+
+## Target Architecture
+
+### A. Adapter model
+
+1. Define a common adapter interface for providers.
+2. Normalize all provider payloads into a shared article schema.
+3. Preserve provider identity and source metadata.
+
+### B. Deduplication model
+
+1. Canonical URL normalization primary key.
+2. Secondary fallback key from normalized title + publication window.
+3. Cross-source dedup performed after provider merge.
+
+### C. Quota and fallback model
+
+1. Per-provider daily/hourly budget controls from config.
+2. Provider failures and quota exhaustion do not fail full ingestion.
+3. Partial results continue through sentiment pipeline.
+
+---
+
+## Implementation Plan
+
+### Workstream 1: Adapter refactor
+
+1. Extract provider interface and move NewsAPI into adapter implementation.
+2. Add second provider adapter behind config flag.
+3. Merge adapter outputs via orchestrator function.
+
+### Workstream 2: Dedup and enrichment
+
+1. Implement canonicalization utility.
+2. Apply cross-source dedup merge policy.
+3. Attach metadata fields for source, confidence hints, and normalized identifiers.
+
+### Workstream 3: Pipeline integration
+
+1. Update `fetch_news` node to call orchestrator.
+2. Ensure no-article routing still works.
+3. Persist source metadata required by Step 4 sentiment enrichment.
+
+---
+
+## Acceptance Criteria
+
+1. At least two providers can be configured and ingested.
+2. Duplicate story suppression works across providers.
+3. Quota limits are enforced without full-pipeline failure.
+4. Sentiment pipeline remains stable on partial provider outages.
+5. New metadata fields are persisted and available to downstream nodes.
+
+---
+
+## Test Plan
+
+1. Unit: adapter normalization for each provider.
+2. Unit: canonicalization and dedup edge cases.
+3. Integration: multi-provider ingestion happy path.
+4. Integration: one-provider-fails fallback behavior.
+5. Integration: quota exhaustion behavior.
+
+Suggested commands:
+
+```bash
+uv run pytest tests/test_sentiment.py -v
+uv run pytest tests/ --cov=alphawatch --cov-report=term-missing
+```
+
+---
+
+## Rollout Plan
+
+1. Enable second provider in staging only.
+2. Compare ingest volume, duplicate rate, and error rates.
+3. Tune quotas and dedup thresholds.
+4. Promote to production with observability alerts enabled.
+
+---
+
+## Risks and Mitigations
+
+1. Risk: Cost increase due to multiple providers.
+   Mitigation: hard quotas and source prioritization order.
+2. Risk: False-positive dedup removes unique stories.
+   Mitigation: conservative matching and audit logs.
+3. Risk: Schema drift from providers.
+   Mitigation: adapter-level validation and fallback defaults.
+
+---
+
+## Deliverables
+
+1. Multi-source adapter framework.
+2. Cross-source dedup and quota logic.
+3. Updated sentiment fetch integration.
+4. Test coverage for multi-source resilience paths.

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -18,11 +18,11 @@ The platform reduces per-company research time from hours to minutes, delivers c
 
 ## Current Focus
 
-1. **Phase 2 Step 1 kickoff** — platform hardening baseline (IAM least-privilege, dependency lock reproducibility, deploy guardrails)
-2. **Phase 2 Step 2 kickoff** — wire `FinancialDataProvider` factory through ingestion entrypoints
-3. **Phase 2 Step 3 design** — full-depth news ingestion source strategy and quotas
-4. **Quality gates** — formalize CI coverage thresholds for Phase 2 critical paths
-5. **Operational readiness** — finalize Phase 2 issue/project tracking artifacts in `github/`
+1. **Phase 2 Step 1 implementation (in repo) complete** — CI coverage gates, production plan-only guardrail, and Step 1 runbook added
+2. **Phase 2 Step 1 external execution pending** — IAM least-privilege validation run, staging full deploy, production plan-only run, migration drill evidence
+3. **Phase 2 Step 2 kickoff** — wire `FinancialDataProvider` factory through ingestion entrypoints
+4. **Phase 2 Step 3 design** — full-depth news ingestion source strategy and quotas
+5. **Operational readiness** — finalize issue-level checklists and execution evidence
 
 ---
 
@@ -32,7 +32,7 @@ The platform reduces per-company research time from hours to minutes, delivers c
 |-------|-------|--------|-------|
 | Phase 0 — Planning & Alignment | PRD, technical specification, architectural direction | ✅ Complete | All planning documents authored; 14-step Phase 1 build order defined |
 | Phase 1 — MVP | Auth, watchlist, EDGAR ingestion, financial API, news, analyst briefs, chat, dashboard, infra | ✅ Complete | Steps 1–14 complete |
-| Phase 2 — Intelligence Expansion | Full news depth, sentiment enrichment, risk flag detection, document upload, comparative intelligence | 🔧 In Progress | 12-step build order defined; issue breakdown in `github/ISSUES` |
+| Phase 2 — Intelligence Expansion | Full news depth, sentiment enrichment, risk flag detection, document upload, comparative intelligence | 🔧 In Progress | 12-step build order defined; tracked in GitHub issues (#26-#40) |
 | Phase 3 — SaaS Hardening | Tenant branding, alert notifications, admin panel, bulk import, brief export, usage tracking | ⏳ Planned | — |
 | Phase 4 — Scale & Polish | Earnings transcripts, watchlist sharing, scheduled briefs, comparison views, audit log, API access | ⏳ Planned | — |
 
@@ -79,6 +79,13 @@ Steps 1–4 can be parallelized; Steps 5–11 are sequential; Steps 12–13 can 
 - [ ] Step 12: Phase 2 release hardening — staging soak, rollback drills, and production cutover checklist
 
 Phase 2 sequencing: Steps 1–2 are preconditions, Steps 3–9 are core feature delivery, Steps 10–12 are quality/release hardening.
+
+### Phase 2 Execution Docs
+
+- [docs/phase2-step1-hardening.md](docs/phase2-step1-hardening.md) — Step 1 platform hardening runbook
+- [docs/phase2-step2-runtime-foundations-spec.md](docs/phase2-step2-runtime-foundations-spec.md) — Step 2 runtime foundations implementation spec
+- [docs/phase2-step3-news-ingestion-spec.md](docs/phase2-step3-news-ingestion-spec.md) — Step 3 full news ingestion implementation spec
+- [docs/phase2-operations-runbook-news-sources.md](docs/phase2-operations-runbook-news-sources.md) — News source operations runbook
 
 ---
 

--- a/scripts/ci/coverage_gate.py
+++ b/scripts/ci/coverage_gate.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Coverage quality gate for critical backend paths.
+
+Reads pytest-cov JSON output and enforces stricter thresholds for selected files.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+CRITICAL_THRESHOLDS: dict[str, float] = {
+    "alphawatch/agents/nodes/chat.py": 90.0,
+    "alphawatch/agents/nodes/brief.py": 90.0,
+    "alphawatch/services/financial.py": 70.0,
+}
+
+
+def _pct(summary: dict[str, object]) -> float:
+    value = summary.get("percent_covered")
+    if isinstance(value, int | float):
+        return float(value)
+    return 0.0
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: coverage_gate.py <coverage.json>")
+        return 2
+
+    report_path = Path(sys.argv[1])
+    if not report_path.exists():
+        print(f"Coverage report not found: {report_path}")
+        return 2
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    files = report.get("files", {})
+    if not isinstance(files, dict):
+        print("Invalid coverage JSON: 'files' field missing")
+        return 2
+
+    failures: list[str] = []
+    for file_path, min_threshold in CRITICAL_THRESHOLDS.items():
+        file_info = files.get(file_path)
+        if not isinstance(file_info, dict):
+            failures.append(
+                f"{file_path}: missing from coverage report (required >= {min_threshold:.1f}%)"
+            )
+            continue
+
+        summary = file_info.get("summary", {})
+        if not isinstance(summary, dict):
+            failures.append(
+                f"{file_path}: invalid summary in coverage report (required >= {min_threshold:.1f}%)"
+            )
+            continue
+
+        covered = _pct(summary)
+        if covered < min_threshold:
+            failures.append(
+                f"{file_path}: {covered:.1f}% < required {min_threshold:.1f}%"
+            )
+        else:
+            print(f"OK {file_path}: {covered:.1f}% >= {min_threshold:.1f}%")
+
+    if failures:
+        print("Critical-path coverage gate failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Critical-path coverage gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
refactor(Issues Phase 2 Step 1)

Closes #27

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the Phase 2 Step 1 platform hardening baseline: CI coverage gates (total floor + critical-path thresholds via `scripts/ci/coverage_gate.py`), lockfile reproducibility checks, a `plan_only` guardrail for production releases, manual-trigger support for staging deployments, and a comprehensive set of Phase 2 execution docs and runbooks.

**Key changes:**
- `ci.yml` — adds lockfile verification steps and a two-stage coverage gate (`--cov-fail-under=74` + `coverage_gate.py`); lockfile checks are placed _after_ the sync/install commands that already enforce their presence, making them redundant in practice.
- `release-prod.yml` — introduces a `plan_only` boolean input with consistent `if:` guards across all apply/rollout/smoke-test steps; the plan-only path correctly queries current ECS task definitions for Terraform plan context.
- `deploy-staging.yml` — adds `workflow_dispatch` for manual staging runs.
- `scripts/ci/coverage_gate.py` — new Python 3.12 script enforcing per-file coverage thresholds; logic is correct but lacks a `try/except` around `json.loads` and has a slightly inaccurate error message when the `files` key exists but is the wrong type.
- Docs — four new Phase 2 docs covering the Step 1 runbook, Step 2 spec, Step 3 spec, and a news-source operations runbook; all are well-structured and internally consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/robustness suggestions with no correctness or reliability impact on the changed paths.

All three comments are P2: redundant lockfile step ordering (doesn't affect correctness, just misleads readers), missing JSON parse guard in a CI-only script (worst case is a traceback in logs, not a silent failure), and a slightly inaccurate error message. None block correct behaviour of the coverage gate, the deployment guardrails, or the lockfile enforcement.

`scripts/ci/coverage_gate.py` and `.github/workflows/ci.yml` have the minor issues noted, but neither is blocking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds lockfile verification steps and a two-stage coverage gate; lockfile checks are placed after the sync/install commands that already enforce lockfile presence, making them redundant. |
| scripts/ci/coverage_gate.py | New critical-path coverage enforcement script; logic is sound but lacks JSON parse error handling and has a minor misleading error message when the `files` key is the wrong type. |
| .github/workflows/release-prod.yml | Adds `plan_only` workflow_dispatch input with well-structured conditional guards; the plan-only path correctly queries current ECS image URIs instead of building new ones. |
| .github/workflows/deploy-staging.yml | Adds `workflow_dispatch` trigger to allow manual staging deployments — clean, minimal, correct change. |
| docs/phase2-step1-hardening.md | New runbook covering IAM validation, lockfile checks, CI gates, deploy guardrails, observability targets, and migration drill — well-structured and complete. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/ci.yml
Line: 30-31

Comment:
**Lockfile check runs after the step that already enforces it**

`uv sync --frozen --all-groups` (the preceding step) will fail immediately if `uv.lock` is absent or stale — the `--frozen` flag is precisely that guard. Running `test -f uv.lock` afterwards can never catch a missing lockfile because the workflow would have already failed. To provide an early, clear diagnostic, move this check **before** the sync step:

```suggestion
      - name: Verify backend lockfile exists
        run: test -f uv.lock

      - name: Sync dependencies
        run: uv sync --frozen --all-groups
```

The same ordering issue applies to the frontend: `npm ci` fails explicitly when `package-lock.json` is absent, so the "Verify frontend lockfile exists" step (line 67) is also effectively dead. Move it before `npm ci` for the same reason.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/ci/coverage_gate.py
Line: 38

Comment:
**Unhandled `JSONDecodeError` on malformed coverage report**

`json.loads(...)` will raise `json.JSONDecodeError` if `coverage.json` is truncated or otherwise malformed (e.g., due to a partial write when pytest is killed mid-run). This produces a raw Python traceback in CI logs rather than the clean error messages used elsewhere in the script. Wrapping the parse in a try/except gives consistent output:

```python
    try:
        report = json.loads(report_path.read_text(encoding="utf-8"))
    except json.JSONDecodeError as exc:
        print(f"Coverage report is not valid JSON: {exc}")
        return 2
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: scripts/ci/coverage_gate.py
Line: 40-42

Comment:
**Misleading error message — "missing" vs wrong type**

The guard checks `not isinstance(files, dict)`, which fires when `files` is present but is the wrong type (e.g., a list). The error message says `'files' field missing`, which is inaccurate in that case and could send a developer looking for a non-existent field.

```suggestion
        print("Invalid coverage JSON: 'files' field is missing or not an object")
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(Issues Phase 2 Step 1)"](https://github.com/bytes0211/aiphawatch/commit/8f810631c7e4709400a18fb4e711d085ad3c0b0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26691141)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->